### PR TITLE
Adds "system_name" field to "shotgun" descriptor.

### DIFF
--- a/python/tank/descriptor/io_descriptor/shotgun_entity.py
+++ b/python/tank/descriptor/io_descriptor/shotgun_entity.py
@@ -87,7 +87,7 @@ class IODescriptorShotgunEntity(IODescriptorDownloadable):
             self._validate_descriptor(
                 descriptor_dict,
                 required=["type", "entity_type", "id", "version", "field"],
-                optional=[]
+                optional=["system_name"]
             )
 
             # convert to int
@@ -125,6 +125,7 @@ class IODescriptorShotgunEntity(IODescriptorDownloadable):
         self._bundle_type = bundle_type
         self._entity_type = descriptor_dict.get("entity_type")
         self._field = descriptor_dict.get("field")
+        self._system_name = descriptor_dict.get("system_name")
 
         # ensure version is an int if specified
         try:
@@ -172,8 +173,11 @@ class IODescriptorShotgunEntity(IODescriptorDownloadable):
                 name = self._name
 
         elif self._mode == self._MODE_ID_BASED:
-            # e.g. 'PipelineConfiguration_1234'
-            name = "%s_%s" % (self._entity_type, self._entity_id)
+            if self._system_name:
+                name = self._system_name
+            else:
+                # e.g. 'PipelineConfiguration_1234'
+                name = "%s_%s" % (self._entity_type, self._entity_id)
 
         return filesystem.create_valid_filename(name)
 


### PR DESCRIPTION
Adding a "system_name" field to the "shotgun" descriptor allows for overriding the default behaviour in the "get_system_name" method which returns the wrong name for use in hook templates where the {engine} tag is used. 
eg, if a descriptor points to a toolkit bundle names "tk-houdini_release_v1.2.3", and a hook path is of the form "path: /some/path/to/{engine}/hook" then the {engine} field will be replaced by {entity_type}_{entity_id}, which will not point to the expected location of, for example, 'tl-houdini/hook' it will instead point to 'customNonProjectEntity01_104/hook'.
Adding an optional field to allow the user to set the "system_name" manually allows the default behaviour to be overridden where required without breaking existing expected behaviour.
This should resolve the issues raised on the community site on pages :- 
- https://community.shotgunsoftware.com/t/possible-hook-path-bug/3365
- https://community.shotgunsoftware.com/t/names-for-apps-frameworks-specified-via-shotgun-descriptors/2989